### PR TITLE
Release v13.5.9: content-hashed assets + SW removal + mobile nav architecture fix

### DIFF
--- a/404.html
+++ b/404.html
@@ -80,18 +80,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/_headers
+++ b/_headers
@@ -1,7 +1,29 @@
 # Cloudflare Pages: Headers configuration
 # https://developers.cloudflare.com/pages/configuration/headers/
+#
+# CACHE STRATEGY (v13.5.9 — content-hashed assets under /assets/)
+# ============================================================================
+# The build script (build.js) renames CSS/JS assets to include a content hash
+# (e.g. styles.css → styles.a3f2c91xxx.css) and places them under /assets/.
+# That subdirectory boundary is intentional: it isolates the immutable rule
+# from rules at the root (notably /sw.js), so Cloudflare's "matching rules
+# inherit all headers" semantics can't accidentally apply `immutable` to
+# files we want to revalidate.
+#
+# Cache invalidation is automatic: when an asset's content changes, its
+# filename changes, the HTML now references a different URL, browsers and
+# CDNs fetch the new file, and the old hashed URL just stops being
+# requested (and naturally evicts from caches).
 
-# All routes — security baseline
+# ============================================================================
+# SECURITY BASELINE (applies to all routes)
+# ----------------------------------------------------------------------------
+# `/*` does NOT set Cache-Control here. Each path category sets its own
+# Cache-Control below. This avoids the inheritance/concatenation problem
+# documented at https://developers.cloudflare.com/pages/configuration/headers/
+# ("If a header is applied twice in the _headers file, the values are joined
+# with a comma separator.")
+# ============================================================================
 /*
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
@@ -9,36 +31,59 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   X-XSS-Protection: 1; mode=block
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.google.com https://maps.google.com; connect-src 'self' https://formspree.io https://www.google-analytics.com https://cloudflareinsights.com; form-action 'self' https://formspree.io;
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.google.com https://maps.google.com; connect-src 'self' https://formspree.io https://www.google-analytics.com https://cloudflareinsights.com; form-action 'self' https://formspree.io; frame-ancestors 'self'; base-uri 'self';
 
-# Long-cache static assets
-/styles.css
+# ============================================================================
+# CONTENT-HASHED ASSETS — cache FOREVER (immutable)
+# ----------------------------------------------------------------------------
+# These rules match files under /assets/, output by build.js. The /sw.js
+# at the root is in a different path namespace and cannot match these globs,
+# so there's zero risk of header conflict.
+# ============================================================================
+/assets/*
   Cache-Control: public, max-age=31536000, immutable
 
-/script.js
-  Cache-Control: public, max-age=31536000, immutable
+# ============================================================================
+# SERVICE WORKER — never cache (must always check for updates)
+# ----------------------------------------------------------------------------
+# /sw.js cannot be content-hashed (Service Worker spec requires a stable URL).
+# In v13.5.9 it's a "tombstone" SW that unregisters legacy SWs from prior
+# versions on the user's next visit, then exits. It MUST never be cached so
+# the browser checks for updates on every page load.
+# ============================================================================
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate
+  Content-Type: application/javascript; charset=utf-8
+  Service-Worker-Allowed: /
 
+# ============================================================================
+# HTML — short cache, must revalidate
+# ----------------------------------------------------------------------------
+# HTML is the entry point that references the hashed asset URLs. Brief edge
+# cache for snappy navigation, but always revalidate so users get the new
+# asset references soon after each deploy.
+# ============================================================================
+/*.html
+  Cache-Control: public, max-age=300, must-revalidate
+
+/
+  Cache-Control: public, max-age=300, must-revalidate
+
+# ============================================================================
+# IMAGES AND FAVICONS — long cache
+# ----------------------------------------------------------------------------
+# Image filenames are stable (content-named like hero-mineral-title.webp),
+# so immutable is safe. To replace an image, give it a new filename.
+# ============================================================================
 /images/*
   Cache-Control: public, max-age=31536000, immutable
 
 /favicon/*
   Cache-Control: public, max-age=31536000, immutable
 
-# HTML — short cache, must revalidate
-/*.html
-  Cache-Control: public, max-age=300, must-revalidate
-
-# Service Worker — must be served from same origin with correct content type
-/sw.js
-  Cache-Control: public, max-age=0, must-revalidate
-  Service-Worker-Allowed: /
-  Content-Type: application/javascript; charset=utf-8
-
-# Critical CSS reference (won't typically be requested directly)
-/critical.css
-  Cache-Control: public, max-age=31536000, immutable
-
-# robots, sitemap, well-known — short cache
+# ============================================================================
+# OPERATIONAL FILES
+# ============================================================================
 /robots.txt
   Cache-Control: public, max-age=3600
 
@@ -52,35 +97,6 @@
   Cache-Control: public, max-age=86400
   Content-Type: text/plain; charset=utf-8
 
-# Internal documentation files — discourage search-engine indexing.
-# These files exist in the deploy for maintainers but are not for public reading.
-# To eliminate from the deploy entirely (maximum privacy), delete them from the
-# build output before pushing to Cloudflare Pages.
-/README.md
-  X-Robots-Tag: noindex, nofollow, noarchive
-  Cache-Control: private, no-store
-
-/EMAIL-ROUTING.md
-  X-Robots-Tag: noindex, nofollow, noarchive
-  Cache-Control: private, no-store
-
-/GA4-SETUP.md
-  X-Robots-Tag: noindex, nofollow, noarchive
-  Cache-Control: private, no-store
-
-/SUBSTANTIATION-CHECKLIST.md
-  X-Robots-Tag: noindex, nofollow, noarchive
-  Cache-Control: private, no-store
-
-# v9: new JavaScript modules — same long-cache treatment as styles.css/script.js
-/email-protect.js
-  Cache-Control: public, max-age=31536000, immutable
-
-/consent.js
-  Cache-Control: public, max-age=31536000, immutable
-
-/analytics.js
-  Cache-Control: public, max-age=31536000, immutable
-
-/smart-form.js
-  Cache-Control: public, max-age=31536000, immutable
+/build-info.json
+  Cache-Control: public, max-age=300
+  Content-Type: application/json; charset=utf-8

--- a/_redirects
+++ b/_redirects
@@ -1,6 +1,15 @@
 # Cloudflare Pages: Redirects configuration
 # https://developers.cloudflare.com/pages/configuration/redirects/
 
+# Block internal documentation files from public access.
+# Note: build.js also excludes these from dist/ so they should never appear
+# at the production origin. This is defense-in-depth in case someone bypasses
+# the build (e.g., manual deploy or build-script failure).
+/README.md                   /                          301
+/EMAIL-ROUTING.md            /                          301
+/GA4-SETUP.md                /                          301
+/SUBSTANTIATION-CHECKLIST.md /                          301
+
 # Strip .html extension — 301 permanent redirects for SEO
 /index.html                  /                          301
 /mineral-title.html          /mineral-title             301
@@ -29,5 +38,5 @@
 /team                    /about                     301
 /portfolio               /case-studies              301
 
-# 404 catch-all (Cloudflare Pages serves /404.html automatically; this ensures it)
+# 404 catch-all (must be last)
 /* /404.html 404

--- a/about.html
+++ b/about.html
@@ -122,17 +122,19 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/process" class="nav-link">Our Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link" aria-current="page">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/process" class="nav-link">Our Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link" aria-current="page">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/build.js
+++ b/build.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/*
+ * BICREA Florida — Production Build Script
+ * ============================================================================
+ *
+ * Purpose: Content-hash CSS and JS assets and place them under /assets/
+ * so they can be cached forever (`Cache-Control: immutable`) without manual
+ * cache invalidation. This is the standard enterprise pattern used by Stripe,
+ * GitHub, Vercel-hosted apps, etc.
+ *
+ * Why the /assets/ subdirectory:
+ *   Cloudflare Pages applies headers from ALL matching `_headers` rules and
+ *   concatenates same-name values with commas. A rule like `/*.js` matching
+ *   `/sw.js` would inherit `Cache-Control: immutable` even if `/sw.js` has
+ *   its own override — the values would join to a malformed Cache-Control.
+ *   Placing hashed assets under /assets/ means the immutable rule applies
+ *   to a path pattern (`/assets/*.js`) that does NOT match `/sw.js` at the
+ *   root, eliminating any possibility of header conflicts.
+ *
+ * How it works:
+ *   1. Read each source asset (styles.css, script.js, etc.)
+ *   2. Compute a short SHA-256 hash of the content (10 chars)
+ *   3. Write the asset to dist/assets/ with the hash in the filename
+ *      e.g.  styles.css  →  dist/assets/styles.a3f2c91xxx.css
+ *            script.js   →  dist/assets/script.b8d2e44yyy.js
+ *   4. Copy all other files (HTML, images, _headers, _redirects, sw.js,
+ *      etc.) to dist/
+ *   5. Rewrite HTML in dist/ to reference /assets/<hashed>
+ *
+ * What does NOT get hashed:
+ *   - sw.js (Service Worker spec requires stable URL — stays at /sw.js)
+ *   - Images (already content-named filenames like hero-mineral-title.webp)
+ *   - Favicons (same)
+ *   - HTML (entry points, must remain referenceable)
+ *
+ * How it's invoked:
+ *   - Locally:           `node build.js`  (writes to ./dist/)
+ *   - Cloudflare Pages:  set build command to `node build.js` and
+ *                        build output directory to `dist`
+ *
+ * Dependencies: none (uses only Node.js built-ins). No npm install needed.
+ * Node version: 18+ for built-in fs APIs.
+ * ============================================================================
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const SRC = process.cwd();
+const OUT = path.join(SRC, 'dist');
+const ASSETS_DIR = 'assets';  // hashed assets go to dist/assets/
+
+// Source asset files to be content-hashed (everything else copied as-is)
+//
+// Note: critical.css is intentionally NOT in this list. Its content is
+// inlined into every HTML file as <style id="critical-css">…</style> at
+// build time outside this script (currently maintained by hand). The
+// source critical.css remains in the repo for developer reference, but
+// it is NOT served as a standalone asset. See IGNORE_NAMES below.
+const HASHED_ASSETS = [
+    'styles.css',
+    'script.js',
+    'consent.js',
+    'analytics.js',
+    'smart-form.js',
+    'email-protect.js',
+];
+
+// Top-level entries to skip when copying. The .md filter below also catches
+// any new documentation file added to the repo without updating this list.
+const IGNORE_NAMES = new Set([
+    'dist',
+    'node_modules',
+    '.git',
+    '.github',
+    'build.js',
+    'critical.css',  // inlined in HTML's <style id="critical-css">, source-only
+]);
+
+function shouldIgnore(name) {
+    if (IGNORE_NAMES.has(name)) return true;
+    // Exclude ALL .md files (in any directory) — these are internal
+    // documentation (READMEs, deploy guides, audit reports). Never public.
+    if (name.endsWith('.md')) return true;
+    // Defensive: common OS artifacts and developer backup files. These
+    // should never reach a deploy. If git is clean these shouldn't exist,
+    // but defensive matching costs nothing.
+    if (name === '.DS_Store' || name === 'Thumbs.db') return true;
+    if (name.endsWith('.bak') || name.endsWith('.orig') ||
+        name.endsWith('.swp') || name.endsWith('~')) return true;
+    return false;
+}
+
+const log = (...a) => console.log('[build]', ...a);
+
+function shortHash(buffer) {
+    return crypto.createHash('sha256').update(buffer).digest('hex').substring(0, 10);
+}
+
+function escapeRegex(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function copyRecursive(src, dst) {
+    // Filter subdirectory entries too — shouldIgnore catches .md files and
+    // OS artifacts no matter how deeply nested. Without this check, files
+    // like favicon/README.md or any .DS_Store would slip through.
+    if (shouldIgnore(path.basename(src))) return;
+    const stat = fs.statSync(src);
+    if (stat.isDirectory()) {
+        if (!fs.existsSync(dst)) fs.mkdirSync(dst, { recursive: true });
+        for (const entry of fs.readdirSync(src)) {
+            copyRecursive(path.join(src, entry), path.join(dst, entry));
+        }
+    } else {
+        fs.copyFileSync(src, dst);
+    }
+}
+
+/* ============================================================
+   STEP 1: Compute hashes for each asset
+   ============================================================ */
+log('Computing content hashes…');
+const hashMap = {};  // 'styles.css' → 'styles.a3f2c91xxx.css'
+const publicPath = {};  // 'styles.css' → '/assets/styles.a3f2c91xxx.css' (URL)
+for (const asset of HASHED_ASSETS) {
+    const srcPath = path.join(SRC, asset);
+    if (!fs.existsSync(srcPath)) {
+        log(`  SKIP (not found): ${asset}`);
+        continue;
+    }
+    const content = fs.readFileSync(srcPath);
+    const hash = shortHash(content);
+    const ext = path.extname(asset);
+    const base = path.basename(asset, ext);
+    const hashed = `${base}.${hash}${ext}`;
+    hashMap[asset] = hashed;
+    publicPath[asset] = `/${ASSETS_DIR}/${hashed}`;
+    log(`  ${asset.padEnd(20)} → ${publicPath[asset]}`);
+}
+
+/* ============================================================
+   STEP 2: Prepare dist/
+   ============================================================ */
+log('Preparing dist/…');
+if (fs.existsSync(OUT)) {
+    fs.rmSync(OUT, { recursive: true, force: true });
+}
+fs.mkdirSync(OUT, { recursive: true });
+fs.mkdirSync(path.join(OUT, ASSETS_DIR), { recursive: true });
+
+/* ============================================================
+   STEP 3: Copy everything except hashed source assets and ignored items
+   ============================================================ */
+log('Copying static files…');
+let copiedCount = 0;
+for (const entry of fs.readdirSync(SRC)) {
+    if (shouldIgnore(entry)) continue;
+    if (HASHED_ASSETS.includes(entry)) continue;  // hashed below
+    copyRecursive(path.join(SRC, entry), path.join(OUT, entry));
+    copiedCount++;
+}
+log(`  ${copiedCount} top-level entries copied`);
+
+/* ============================================================
+   STEP 4: Write hashed assets to dist/assets/
+   ============================================================ */
+log('Writing hashed assets to dist/assets/…');
+for (const [original, hashed] of Object.entries(hashMap)) {
+    const content = fs.readFileSync(path.join(SRC, original));
+    fs.writeFileSync(path.join(OUT, ASSETS_DIR, hashed), content);
+}
+
+/* ============================================================
+   STEP 5: Rewrite HTML files in dist/ to reference hashed URLs
+   ============================================================ */
+log('Rewriting HTML references…');
+const htmlFiles = fs.readdirSync(OUT).filter((f) => f.endsWith('.html'));
+let totalRewrites = 0;
+for (const hf of htmlFiles) {
+    const filePath = path.join(OUT, hf);
+    let html = fs.readFileSync(filePath, 'utf8');
+    let fileRewrites = 0;
+    for (const [original, hashed] of Object.entries(hashMap)) {
+        // Match  href="/file.css"  or  src="/file.js"  optionally with ?query
+        // We require a whitespace before href/src to avoid matching `data-href`,
+        // `data-src`, or anything else where href/src is part of a longer
+        // attribute name.
+        const pat = new RegExp(
+            `(\\s)(href|src)="/${escapeRegex(original)}(?:\\?[^"]*)?"`,
+            'g'
+        );
+        const newHtml = html.replace(pat, `$1$2="${publicPath[original]}"`);
+        const matches = (html.match(pat) || []).length;
+        if (matches > 0) {
+            html = newHtml;
+            fileRewrites += matches;
+        }
+    }
+    fs.writeFileSync(filePath, html);
+    totalRewrites += fileRewrites;
+    if (fileRewrites > 0) {
+        log(`  ${hf}: ${fileRewrites} refs rewritten`);
+    }
+}
+log(`  Total: ${totalRewrites} references updated across ${htmlFiles.length} HTML files`);
+
+/* ============================================================
+   STEP 6: Write build-info.json (debugging aid)
+   ============================================================ */
+const buildInfo = {
+    timestamp: new Date().toISOString(),
+    nodeVersion: process.version,
+    assetsBaseUrl: `/${ASSETS_DIR}/`,
+    hashedAssets: hashMap,
+    publicPaths: publicPath,
+    totalRewrites,
+};
+fs.writeFileSync(
+    path.join(OUT, 'build-info.json'),
+    JSON.stringify(buildInfo, null, 2)
+);
+
+log('Build complete.');
+log(`Output directory: ${OUT}`);
+log(`Hashed assets: ${Object.keys(hashMap).length} → dist/${ASSETS_DIR}/`);
+log(`HTML rewrites: ${totalRewrites}`);

--- a/case-studies.html
+++ b/case-studies.html
@@ -89,18 +89,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/contact.html
+++ b/contact.html
@@ -99,18 +99,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/disclosures.html
+++ b/disclosures.html
@@ -92,18 +92,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/distressed-properties.html
+++ b/distressed-properties.html
@@ -164,17 +164,19 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link" aria-current="page">Distressed Property Solutions</a></li>
-      <li><a href="/process" class="nav-link">Our Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link" aria-current="page">Distressed Property Solutions</a></li>
+    <li><a href="/process" class="nav-link">Our Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/index.html
+++ b/index.html
@@ -186,18 +186,20 @@
     </button>
   </div>
 
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <!-- ==================== TRUST STRIP ==================== -->
 <div class="contact-bar">

--- a/methodology.html
+++ b/methodology.html
@@ -130,18 +130,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link" aria-current="page">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link" aria-current="page">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/mineral-title.html
+++ b/mineral-title.html
@@ -201,17 +201,19 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link" aria-current="page">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/process" class="nav-link">Our Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link" aria-current="page">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/process" class="nav-link">Our Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/privacy.html
+++ b/privacy.html
@@ -83,16 +83,18 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/process.html
+++ b/process.html
@@ -89,18 +89,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 

--- a/script.js
+++ b/script.js
@@ -76,6 +76,22 @@
     var navBackdrop = null;
 
     if (navToggle && navMobile) {
+        /* CRITICAL: Move the mobile drawer to be a direct child of <body>.
+           Why: the drawer is `position: fixed` and needs to be positioned
+           relative to the viewport. But its parent <nav class="navbar"> has
+           `backdrop-filter` for the frosted-glass effect, and per CSS spec,
+           ANY element with `backdrop-filter` (or `filter`, `transform`,
+           `perspective`, `contain: paint`) creates a containing block that
+           traps position:fixed children inside it. Without this move, the
+           drawer would be positioned relative to the (64px-tall) navbar
+           instead of the viewport — collapsing to near-zero height and
+           appearing as a thin sliver at the top of the screen on mobile.
+           Moving the element to <body> at runtime escapes the trap without
+           requiring changes to every HTML file. */
+        if (navMobile.parentNode !== document.body) {
+            document.body.appendChild(navMobile);
+        }
+
         // Inject a backdrop element on demand (CSS in styles.css handles the rest)
         navBackdrop = document.createElement('div');
         navBackdrop.className = 'nav-backdrop';

--- a/script.js
+++ b/script.js
@@ -76,18 +76,17 @@
     var navBackdrop = null;
 
     if (navToggle && navMobile) {
-        /* CRITICAL: Move the mobile drawer to be a direct child of <body>.
-           Why: the drawer is `position: fixed` and needs to be positioned
-           relative to the viewport. But its parent <nav class="navbar"> has
-           `backdrop-filter` for the frosted-glass effect, and per CSS spec,
-           ANY element with `backdrop-filter` (or `filter`, `transform`,
-           `perspective`, `contain: paint`) creates a containing block that
-           traps position:fixed children inside it. Without this move, the
-           drawer would be positioned relative to the (64px-tall) navbar
-           instead of the viewport — collapsing to near-zero height and
-           appearing as a thin sliver at the top of the screen on mobile.
-           Moving the element to <body> at runtime escapes the trap without
-           requiring changes to every HTML file. */
+        /* DEFENSIVE: Ensure the mobile drawer is a direct child of <body>.
+           As of v13.5.9 the drawer is correctly placed as a sibling of
+           <nav class="navbar"> in HTML, so this check is a no-op on
+           current pages. It remains as defense-in-depth: if a future page
+           accidentally nests the drawer inside the navbar (or any other
+           element with backdrop-filter / filter / transform / perspective
+           / contain:paint), CSS spec creates a containing block that
+           traps position:fixed children, collapsing the drawer's
+           rendered height. This guard moves the drawer to <body> at
+           runtime to escape any such trap. Event listeners attached
+           below remain valid because they are bound to the element. */
         if (navMobile.parentNode !== document.body) {
             document.body.appendChild(navMobile);
         }
@@ -100,6 +99,7 @@
 
         function openNav() {
             navMobile.classList.add('is-open');
+            navMobile.setAttribute('aria-hidden', 'false');
             navBackdrop.classList.add('is-active');
             navToggle.setAttribute('aria-expanded', 'true');
             navToggle.setAttribute('aria-label', 'Close menu');
@@ -112,6 +112,7 @@
         }
         function closeNav(returnFocus) {
             navMobile.classList.remove('is-open');
+            navMobile.setAttribute('aria-hidden', 'true');
             navBackdrop.classList.remove('is-active');
             navToggle.setAttribute('aria-expanded', 'false');
             navToggle.setAttribute('aria-label', 'Open menu');

--- a/script.js
+++ b/script.js
@@ -58,7 +58,19 @@
         progressBar.style.setProperty('--progress', pct + '%');
     }
 
-    /* ---------------- Mobile nav toggle (v6: backdrop + focus trap) ---------------- */
+    /* ---------------- Mobile nav toggle (v7: class-name fix) ----------------
+       The single bug fixed in v7: this code previously toggled '.open' on
+       the .nav-mobile drawer, but the CSS rule is .nav-mobile.is-open
+       (matches the 'is-' state-class convention used by .is-active,
+       .is-completed, .is-visible, etc throughout this site). Result:
+       tapping the hamburger fired the JS handler but no visual styles
+       activated — drawer stayed at default state (translateY(-100%),
+       opacity:0, pointer-events:none).
+
+       Fix is minimal: only the three classList operations changed from
+       'open' to 'is-open'. Body scroll-lock preserved (overflow:hidden
+       only — NOT position:fixed, which broke iOS link navigation in an
+       earlier attempt). */
     var navToggle = document.getElementById('navToggle');
     var navMobile = document.getElementById('navMobile');
     var navBackdrop = null;
@@ -71,7 +83,7 @@
         document.body.appendChild(navBackdrop);
 
         function openNav() {
-            navMobile.classList.add('open');
+            navMobile.classList.add('is-open');
             navBackdrop.classList.add('is-active');
             navToggle.setAttribute('aria-expanded', 'true');
             navToggle.setAttribute('aria-label', 'Close menu');
@@ -83,14 +95,14 @@
             }, 80);
         }
         function closeNav(returnFocus) {
-            navMobile.classList.remove('open');
+            navMobile.classList.remove('is-open');
             navBackdrop.classList.remove('is-active');
             navToggle.setAttribute('aria-expanded', 'false');
             navToggle.setAttribute('aria-label', 'Open menu');
             document.body.style.overflow = '';
             if (returnFocus) navToggle.focus();
         }
-        function isOpen() { return navMobile.classList.contains('open'); }
+        function isOpen() { return navMobile.classList.contains('is-open'); }
 
         navToggle.addEventListener('click', function () {
             if (isOpen()) closeNav(true); else openNav();
@@ -360,13 +372,28 @@
         });
     }
 
-    /* ---------------- Service Worker registration ---------------- */
-    if ('serviceWorker' in navigator && location.protocol === 'https:') {
-        window.addEventListener('load', function () {
-            navigator.serviceWorker.register('/sw.js').catch(function () {
-                // Silent fallback — SW is enhancement, not requirement
-            });
-        });
+    /* ---------------- Service Worker DEACTIVATION ----------------
+       v13.5.9 removed the Service Worker entirely. The site is now served
+       as standard static files with proper cache headers — no SW
+       interception layer. This block actively unregisters any SW that
+       earlier versions (v13.5.6-v13.5.8) installed.
+
+       Belt-and-suspenders alongside the tombstone /sw.js: even if a user
+       has an old SW that for some reason doesn't fetch the tombstone,
+       this client-side code will unregister it on their next page load.
+       After ~30 days from this deploy, this block can be deleted along
+       with the sw.js tombstone file. */
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.getRegistrations().then(function (regs) {
+            regs.forEach(function (reg) { reg.unregister(); });
+        }).catch(function () { /* silent */ });
+        if ('caches' in window) {
+            caches.keys().then(function (keys) {
+                keys.forEach(function (k) {
+                    if (k.indexOf('bicrea-') === 0) caches.delete(k);
+                });
+            }).catch(function () { /* silent */ });
+        }
     }
 })();
 

--- a/styles.css
+++ b/styles.css
@@ -654,7 +654,7 @@ section[style*="--bg-secondary"] .card-cta-tight {
     background: rgba(10, 10, 10, 0.97);
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);
-    z-index: 290;
+    z-index: 295;
     padding: var(--space-6) var(--container-padding);
     transform: translateY(-100%);
     opacity: 0;

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,7 @@ ul, ol {
     --bg-card:         #161616;
     --bg-card-alt:     #1a1a1a;
     --bg-elevated:     #1f1f1f;
+    --bg-tertiary:     #242424;  /* hover-fill for close buttons + tertiary surfaces */
 
     --text-primary:    #f5f5f7;
     --text-secondary:  rgba(245, 245, 247, 0.78);
@@ -124,6 +125,7 @@ ul, ol {
 
     --error:   #ef4444;
     --success: #22c55e;
+    --warning: #f59e0b;  /* amber — legal-warning panels, foreclosure ack accents */
 
     /* --- Shadows --- */
     --shadow-sm:      0 1px 2px rgba(0, 0, 0, 0.4);
@@ -2179,15 +2181,34 @@ section[style*="--bg-secondary"] .methodology-step {
     display: block;
 }
 
+/* ============================================================
+   METHODOLOGY CHAIN VISUALIZATION
+
+   Visibility model (v3): the default (inactive) state must already
+   be visible — previously these elements rendered against the dark
+   background with near-zero contrast (.inner fill = --bg-card =
+   same color as page, .outer fill = 8% gold, strokes = subtle
+   --border-default), so the user saw text labels floating in space
+   with no visible chain.
+
+   New baseline: muted-gold defaults (~30% opacity) so the entire
+   chain reads as one continuous visual the moment it scrolls into
+   view. Active state still brightens to full gold with scale up,
+   and completed state sits between the two. Progressive enhancement
+   pattern: each state is an *additive* visual emphasis on top of an
+   already-visible baseline.
+   ============================================================ */
+
 .chain-line {
-    stroke: var(--border-default);
-    stroke-width: 1.5;
+    stroke: rgba(212, 175, 55, 0.28);
+    stroke-width: 2;
     fill: none;
-    transition: stroke 0.4s var(--ease-out);
+    transition: stroke 0.4s var(--ease-out), stroke-width 0.4s var(--ease-out);
 }
 
 .chain-line.is-active {
     stroke: var(--primary-gold);
+    stroke-width: 2.5;
 }
 
 .chain-node {
@@ -2199,24 +2220,24 @@ section[style*="--bg-secondary"] .methodology-step {
 }
 
 .chain-node .outer {
-    fill: rgba(212, 175, 55, 0.08);
-    stroke: var(--border-gold);
+    fill: rgba(212, 175, 55, 0.12);
+    stroke: rgba(212, 175, 55, 0.55);
     stroke-width: 1.5;
     transition: fill 0.4s var(--ease-out), stroke 0.4s var(--ease-out);
 }
 
 .chain-node .inner {
-    fill: var(--bg-card);
-    stroke: var(--border-default);
+    fill: var(--bg-elevated);
+    stroke: rgba(212, 175, 55, 0.40);
     stroke-width: 1;
-    transition: fill 0.4s var(--ease-out);
+    transition: fill 0.4s var(--ease-out), stroke 0.4s var(--ease-out);
 }
 
 .chain-node > text {
     font-family: var(--font-heading);
     font-size: 13px;
     font-weight: 700;
-    fill: var(--text-muted);
+    fill: rgba(212, 175, 55, 0.85);
     text-anchor: middle;
     dominant-baseline: central;
     transition: fill 0.4s var(--ease-out);
@@ -2227,38 +2248,39 @@ section[style*="--bg-secondary"] .methodology-step {
 }
 
 .chain-node.is-active .outer {
-    fill: rgba(212, 175, 55, 0.18);
+    fill: rgba(212, 175, 55, 0.22);
     stroke: var(--primary-gold);
 }
 
 .chain-node.is-active .inner {
     fill: var(--primary-gold);
+    stroke: var(--primary-gold);
 }
 
 .chain-node.is-active > text {
     fill: var(--bg-primary);
 }
 
-/* Progressive state: completed steps (everything before current) get a
-   subdued gold accent so the user can see how far they've come. */
+/* Completed state: steps the user has scrolled past — visibly gold-tinted
+   to show progress, but distinct from the bright active node. */
 .chain-node.is-completed .outer {
-    fill: rgba(212, 175, 55, 0.10);
-    stroke: rgba(212, 175, 55, 0.55);
+    fill: rgba(212, 175, 55, 0.18);
+    stroke: rgba(212, 175, 55, 0.75);
 }
 
 .chain-node.is-completed .inner {
-    fill: var(--bg-card);
-    stroke: rgba(212, 175, 55, 0.4);
+    fill: var(--bg-elevated);
+    stroke: rgba(212, 175, 55, 0.60);
 }
 
 .chain-node.is-completed > text {
     fill: var(--primary-gold);
 }
 
-/* The final star node (8th node, "Delivered") always reads as the
-   destination — fully gold regardless of scroll position. */
+/* The final star node ("Delivered") always reads as the destination —
+   fully gold regardless of scroll position. */
 .chain-node-star .outer {
-    fill: rgba(212, 175, 55, 0.16);
+    fill: rgba(212, 175, 55, 0.20);
     stroke: var(--primary-gold);
 }
 
@@ -3397,11 +3419,24 @@ section[style*="--bg-secondary"] .map-link {
     @keyframes smart-spin {
         to { transform: rotate(360deg); }
     }
+    /* Form-success animations: subtle rise-in for the success panel, gentle
+       pulse on the success icon. GPU-only properties (transform/opacity),
+       so cheap. Both respect prefers-reduced-motion below. */
+    @keyframes success-rise {
+        from { opacity: 0; transform: translateY(24px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes success-icon-pulse {
+        0%, 100% { transform: scale(1); }
+        50%      { transform: scale(1.06); }
+    }
     @media (prefers-reduced-motion: reduce) {
         .smart-spinner {
             animation: smart-spin 1.8s linear infinite;
             opacity: 0.5;
         }
+        .smart-form-success.is-shown { animation: none; }
+        .smart-form-success-icon     { animation: none; }
     }
 
     /* Mobile nav backdrop — for click-outside-to-close affordance */

--- a/sw.js
+++ b/sw.js
@@ -1,141 +1,64 @@
-/* BICREA Florida — Service Worker
- * Caching strategy:
- *   - HTML pages: network-first (always try fresh, fall back to cache)
- *   - CSS/JS: stale-while-revalidate (instant from cache, revalidate in background)
- *   - Images: cache-first (immutable, long-cache)
- *   - Cross-origin (Google Fonts): cache-first with reasonable expiry
+/*
+ * BICREA Florida — Tombstone Service Worker (v13.5.9)
+ * ============================================================================
  *
- * Install strategy: best-effort (Promise.allSettled, not addAll). A missing
- * file in the shell list should NOT prevent the SW from activating — it just
- * means that file isn't precached and will fetch from network on first use.
- * Previously we used cache.addAll() which is atomic: any single 404 caused
- * the whole install to reject, leaving the SW in "redundant" state forever.
+ * Starting in v13.5.9, bicrea.com no longer uses a Service Worker. This file
+ * exists solely to clean up Service Workers installed by earlier versions
+ * (v13.5.6 through v13.5.8). Those SWs had caching strategies that occasionally
+ * served stale code during deploys; eliminating the SW entirely is the
+ * simplest robust path for a marketing site.
  *
- * Versioned cache name — bump on deploys to invalidate
+ * When a user who previously had an SW installed visits the site, the browser
+ * automatically checks /sw.js for an update. The browser sees this new
+ * version, installs it, and activates it (skipWaiting forces immediate
+ * activation). On activation, this tombstone:
+ *
+ *   1. Claims all open tabs
+ *   2. Deletes every cache the site previously created
+ *   3. Unregisters itself
+ *   4. Force-reloads open tabs so they pick up fresh code with no SW
+ *
+ * Subsequent page loads will register no Service Worker at all (the
+ * registration code was removed from script.js in v13.5.9). The site
+ * behaves as a standard CDN-served static site.
+ *
+ * NOTE: After ~30 days from deploy, this file can safely be deleted from
+ * the repo. At that point, every plausible repeat visitor will have come
+ * through and had their SW cleaned up. New visitors never had an SW to
+ * begin with.
+ *
+ * No fetch handler is registered — all requests pass through to the network
+ * unmodified, exactly as if there were no Service Worker.
+ * ============================================================================
  */
-const VERSION = 'v13.5.6-2026-05-11';
-const SHELL_CACHE = 'bicrea-shell-' + VERSION;
-const PAGES_CACHE = 'bicrea-pages-' + VERSION;
-const ASSETS_CACHE = 'bicrea-assets-' + VERSION;
-const FONTS_CACHE = 'bicrea-fonts-' + VERSION;
 
-// Files to pre-cache on install (the shell). Best-effort: missing files are
-// silently skipped.
-const SHELL_URLS = [
-    '/',
-    '/styles.css',
-    '/script.js',
-    '/favicon/favicon.svg'
-];
-
-// Install: best-effort pre-cache (no atomic failures)
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(SHELL_CACHE).then((cache) => {
-            // Cache each file independently. A failure for one URL doesn't
-            // reject the whole install.
-            return Promise.allSettled(
-                SHELL_URLS.map((url) =>
-                    cache.add(url).catch((err) => {
-                        // Log but don't propagate — keep install successful
-                        console.warn('[SW] precache skip:', url, err.message);
-                    })
-                )
-            );
-        }).then(() => self.skipWaiting())
-    );
+self.addEventListener('install', () => {
+    // Skip the "waiting" phase — activate immediately
+    self.skipWaiting();
 });
 
-// Activate: clean up old version caches
 self.addEventListener('activate', (event) => {
-    const VALID = [SHELL_CACHE, PAGES_CACHE, ASSETS_CACHE, FONTS_CACHE];
     event.waitUntil(
-        caches.keys().then((keys) => {
-            return Promise.all(
-                keys.filter((k) => k.startsWith('bicrea-') && !VALID.includes(k))
-                    .map((k) => caches.delete(k))
-            );
-        }).then(() => self.clients.claim())
+        (async () => {
+            // 1. Take control of all open tabs from any prior SW
+            await self.clients.claim();
+
+            // 2. Delete every cache this site created in prior versions
+            const cacheKeys = await caches.keys();
+            const bicreaCaches = cacheKeys.filter((k) => k.startsWith('bicrea-'));
+            await Promise.all(bicreaCaches.map((k) => caches.delete(k)));
+
+            // 3. Unregister this Service Worker
+            await self.registration.unregister();
+
+            // 4. Force-reload all open tabs so they get fresh code without
+            //    any SW interference
+            const clients = await self.clients.matchAll({ type: 'window' });
+            for (const client of clients) {
+                if ('navigate' in client) {
+                    client.navigate(client.url);
+                }
+            }
+        })()
     );
 });
-
-// Fetch: routing strategy
-self.addEventListener('fetch', (event) => {
-    const req = event.request;
-    if (req.method !== 'GET') return;
-
-    const url = new URL(req.url);
-
-    // Skip Formspree, analytics, and any 3rd party we don't want to cache
-    if (url.hostname.includes('formspree.io')) return;
-    if (url.hostname.includes('google-analytics.com')) return;
-    if (url.hostname.includes('googletagmanager.com')) return;
-
-    // Google Fonts — cache-first
-    if (url.hostname === 'fonts.googleapis.com' || url.hostname === 'fonts.gstatic.com') {
-        event.respondWith(cacheFirst(req, FONTS_CACHE));
-        return;
-    }
-
-    // Same-origin only beyond this point
-    if (url.origin !== self.location.origin) return;
-
-    // HTML — network-first
-    if (req.destination === 'document' || req.headers.get('accept')?.includes('text/html')) {
-        event.respondWith(networkFirst(req, PAGES_CACHE));
-        return;
-    }
-
-    // CSS/JS — stale-while-revalidate
-    if (req.destination === 'style' || req.destination === 'script') {
-        event.respondWith(staleWhileRevalidate(req, SHELL_CACHE));
-        return;
-    }
-
-    // Images — cache-first
-    if (req.destination === 'image') {
-        event.respondWith(cacheFirst(req, ASSETS_CACHE));
-        return;
-    }
-
-    // Default: stale-while-revalidate
-    event.respondWith(staleWhileRevalidate(req, ASSETS_CACHE));
-});
-
-async function cacheFirst(req, cacheName) {
-    const cache = await caches.open(cacheName);
-    const cached = await cache.match(req);
-    if (cached) return cached;
-    try {
-        const response = await fetch(req);
-        if (response && response.status === 200) cache.put(req, response.clone());
-        return response;
-    } catch (e) {
-        return cached || Response.error();
-    }
-}
-
-async function networkFirst(req, cacheName) {
-    const cache = await caches.open(cacheName);
-    try {
-        const response = await fetch(req);
-        if (response && response.status === 200) cache.put(req, response.clone());
-        return response;
-    } catch (e) {
-        const cached = await cache.match(req);
-        if (cached) return cached;
-        // Offline fallback to homepage if it exists in cache
-        const home = await caches.match('/');
-        return home || Response.error();
-    }
-}
-
-async function staleWhileRevalidate(req, cacheName) {
-    const cache = await caches.open(cacheName);
-    const cached = await cache.match(req);
-    const fetchPromise = fetch(req).then((response) => {
-        if (response && response.status === 200) cache.put(req, response.clone());
-        return response;
-    }).catch(() => cached);
-    return cached || fetchPromise;
-}

--- a/terms.html
+++ b/terms.html
@@ -89,18 +89,20 @@
       <span></span><span></span><span></span>
     </button>
   </div>
-  <div class="nav-mobile" id="navMobile">
-    <ul>
-      <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
-      <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
-      <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
-      <li><a href="/process" class="nav-link">Engagement Process</a></li>
-      <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
-      <li><a href="/about" class="nav-link">About BICREA</a></li>
-      <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
-    </ul>
-  </div>
 </nav>
+
+<!-- Mobile navigation drawer (sibling of navbar to avoid CSS containing-block trap from navbar's backdrop-filter) -->
+<div class="nav-mobile" id="navMobile" role="dialog" aria-modal="true" aria-label="Mobile navigation menu" aria-hidden="true">
+  <ul>
+    <li><a href="/mineral-title" class="nav-link">Mineral Title Research</a></li>
+    <li><a href="/distressed-properties" class="nav-link">Distressed Property Solutions</a></li>
+    <li><a href="/methodology" class="nav-link">Our Methodology</a></li>
+    <li><a href="/process" class="nav-link">Engagement Process</a></li>
+    <li><a href="/case-studies" class="nav-link">Case Studies</a></li>
+    <li><a href="/about" class="nav-link">About BICREA</a></li>
+    <li><a href="/contact" class="nav-link nav-cta">Get In Touch</a></li>
+  </ul>
+</div>
 
 <main id="main">
 


### PR DESCRIPTION
Release v13.5.9 — complete rollout:
- Content-hashed assets (immutable caching)
- Service Worker removal + cleanup
- Mobile nav architectural refactor (drawer extracted from navbar to sibling)
- ARIA dialog upgrade for mobile drawer
- Drawer z-index above backdrop scrim
- v13.5.6 bug fixes

Tested: Mac DevTools clean, iPhone Safari mobile drawer working.
Preview: 065faf8f.bicrea-website.pages.dev

Rollback: Cloudflare → Pages → bicrea-website → Deployments → 7527d76 → Rollback.